### PR TITLE
feat: Create empty json format Subtask.json and CreatedResult.json

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -67,6 +67,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4
         with:
+          ext-csharp-version: ${{ env.EXT_CSHARP_VERSION }}
           ref: ${{ github.ref }}
 
       - name: Install Dependencies

--- a/src/TaskReRunner/Program.cs
+++ b/src/TaskReRunner/Program.cs
@@ -201,12 +201,23 @@ internal static class Program
                              task.Value);
     }
 
+    if (File.Exists(copyPath + Path.DirectorySeparatorChar + "CreatedResults.json") == false)
+    {
+      File.WriteAllText(copyPath + Path.DirectorySeparatorChar + "CreatedResults.json",
+                        "{}");
+    }
+
     var jsonString    = File.ReadAllText(copyPath + Path.DirectorySeparatorChar + "CreatedResults.json");
     var resultOutputs = JsonSerializer.Deserialize<ConcurrentDictionary<string, ResultRaw>>(jsonString);
 
+    if (File.Exists(copyPath + Path.DirectorySeparatorChar + "Subtasks.json") == false)
+    {
+      File.WriteAllText(copyPath + Path.DirectorySeparatorChar + "Subtasks.json",
+                        "{}");
+    }
+
     var jsonStringTasks = File.ReadAllText(copyPath + Path.DirectorySeparatorChar + "Subtasks.json");
     var tasksOutputs    = JsonSerializer.Deserialize<ConcurrentDictionary<string, TaskSummary>>(jsonStringTasks);
-
 
     if (resultOutputs!.Count == storage.Results.Count)
     {
@@ -401,7 +412,7 @@ internal static class Program
     // Define the options for the application with their description and default value
     var path = new Option<string>("--path",
                                   description: "Path to the JSON file containing the data needed to rerun the Task.",
-                                  getDefaultValue: () => "task.json");
+                                  getDefaultValue: () => "Task.json");
 
     var force = new Option<bool>("--force",
                                  description: "Allow this program previous output deletion",


### PR DESCRIPTION
## Motivation

When running TaskReRunner, the tool previously required `CreatedResults.json` and `Subtasks.json` to already exist in the working directory. If they were absent, the program would crash with a file-not-found error. This change makes the tool more resilient by gracefully initializing these files when they are missing, reducing friction for first-time runs or clean environments.

## Description

- **`src/TaskReRunner/Program.cs`**: Added existence checks before reading `CreatedResults.json` and `Subtasks.json`. If either file is absent, it is created with an empty JSON object (`{}`) before being read. Also corrected the default value for the `--path` option from `"task.json"` to `"Task.json"` to match the expected casing.
- **`.github/workflows/build.yml`**: Added the `ext-csharp-version` input to the checkout step so the correct C# extension version is passed during the CI build.

## Testing

The changes were verified by running the tool against a directory without pre-existing `CreatedResults.json` or `Subtasks.json` files to confirm that both files are auto-created with `{}` content and that execution proceeds normally. Existing behavior when the files are present is unchanged.

## Impact

- Users no longer need to manually create empty `CreatedResults.json` and `Subtasks.json` files before the first run.
- The default task file name is now `Task.json` (capital T) — users relying on the lowercase `task.json` default will need to rename their file or pass the path explicitly via `--path`.
- CI pipeline now correctly propagates the C# extension version during checkout.

## Additional Information

The `{}` empty object is the correct seed value because the files are deserialized into `ConcurrentDictionary<string, ...>`, which maps to an empty JSON object.

## Checklist

- [ ] My code adheres to the coding and style guidelines of the project.
- [x] I have performed a self-review of my code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] I have thoroughly tested my modifications and added tests when necessary.
- [x] Tests pass locally and in the CI.
- [x] I have assessed the performance impact of my modifications.
