### PR TITLE
chore: Update year in copyright

### DIFF
--- a/src/TaskDumper/Program.cs
+++ b/src/TaskDumper/Program.cs
@@ -1,6 +1,6 @@
 // This file is part of the ArmoniK project
 // 
-// Copyright (C) ANEO, 2021-2025. All rights reserved.
+// Copyright (C) ANEO, 2021-2026. All rights reserved.
 // 
 // Licensed under the Apache License, Version 2.0 (the "License")
 // you may not use this file except in compliance with the License.

--- a/src/TaskReRunner/Program.cs
+++ b/src/TaskReRunner/Program.cs
@@ -1,6 +1,6 @@
 // This file is part of the ArmoniK project
 // 
-// Copyright (C) ANEO, 2021-2025. All rights reserved.
+// Copyright (C) ANEO, 2021-2026. All rights reserved.
 // 
 // Licensed under the Apache License, Version 2.0 (the "License")
 // you may not use this file except in compliance with the License.

--- a/src/TaskReRunner/ReRunnerAgent.cs
+++ b/src/TaskReRunner/ReRunnerAgent.cs
@@ -1,6 +1,6 @@
 // This file is part of the ArmoniK project
 // 
-// Copyright (C) ANEO, 2021-2025. All rights reserved.
+// Copyright (C) ANEO, 2021-2026. All rights reserved.
 // 
 // Licensed under the Apache License, Version 2.0 (the "License")
 // you may not use this file except in compliance with the License.

--- a/src/TaskReRunner/Server.cs
+++ b/src/TaskReRunner/Server.cs
@@ -1,6 +1,6 @@
 // This file is part of the ArmoniK project
 // 
-// Copyright (C) ANEO, 2021-2025. All rights reserved.
+// Copyright (C) ANEO, 2021-2026. All rights reserved.
 // 
 // Licensed under the Apache License, Version 2.0 (the "License")
 // you may not use this file except in compliance with the License.

--- a/src/TaskReRunner/Storage/AgentStorage.cs
+++ b/src/TaskReRunner/Storage/AgentStorage.cs
@@ -1,6 +1,6 @@
 // This file is part of the ArmoniK project
 // 
-// Copyright (C) ANEO, 2021-2025. All rights reserved.
+// Copyright (C) ANEO, 2021-2026. All rights reserved.
 // 
 // Licensed under the Apache License, Version 2.0 (the "License")
 // you may not use this file except in compliance with the License.

--- a/src/TaskReRunner/Storage/Result.cs
+++ b/src/TaskReRunner/Storage/Result.cs
@@ -1,6 +1,6 @@
 // This file is part of the ArmoniK project
 // 
-// Copyright (C) ANEO, 2021-2025. All rights reserved.
+// Copyright (C) ANEO, 2021-2026. All rights reserved.
 // 
 // Licensed under the Apache License, Version 2.0 (the "License")
 // you may not use this file except in compliance with the License.

--- a/src/TaskReRunner/Storage/TaskData.cs
+++ b/src/TaskReRunner/Storage/TaskData.cs
@@ -1,6 +1,6 @@
 // This file is part of the ArmoniK project
 // 
-// Copyright (C) ANEO, 2021-2025. All rights reserved.
+// Copyright (C) ANEO, 2021-2026. All rights reserved.
 // 
 // Licensed under the Apache License, Version 2.0 (the "License")
 // you may not use this file except in compliance with the License.

--- a/test/ReRunnerAgentTest/ReRunnerAgentTest.cs
+++ b/test/ReRunnerAgentTest/ReRunnerAgentTest.cs
@@ -1,6 +1,6 @@
 // This file is part of the ArmoniK project
 // 
-// Copyright (C) ANEO, 2021-2025. All rights reserved.
+// Copyright (C) ANEO, 2021-2026. All rights reserved.
 // 
 // Licensed under the Apache License, Version 2.0 (the "License")
 // you may not use this file except in compliance with the License.


### PR DESCRIPTION
# Motivation
Update of the year in copyright notices to reflect the current year (2026).

# Description
Modification of file headers containing copyright notices to replace the previous year with 2026. This update ensures that the project's legal information remains up to date.

This modification is part of the regular maintenance of the project's legal notices.